### PR TITLE
fixed requirements for google colab

### DIFF
--- a/infra/requirements.txt
+++ b/infra/requirements.txt
@@ -1,5 +1,5 @@
-torch==1.7.1+cu110
-torchvision==0.8.2+cu110
+torch==1.6.0
+torchvision==0.7.0
 tensorboard
 matplotlib
 git+https://github.com/tinyobjloader/tinyobjloader.git#subdirectory=python
@@ -14,4 +14,3 @@ moviepy
 opencv-python
 plyfile
 polyscope
-pysdf

--- a/infra/requirements.txt
+++ b/infra/requirements.txt
@@ -1,5 +1,5 @@
-torch==1.6.0
-torchvision==0.7.0
+torch==1.7.1+cu110
+torchvision==0.8.2+cu110
 tensorboard
 matplotlib
 git+https://github.com/tinyobjloader/tinyobjloader.git#subdirectory=python
@@ -14,3 +14,4 @@ moviepy
 opencv-python
 plyfile
 polyscope
+pysdf

--- a/sdf-net/lib/datasets/MeshDataset.py
+++ b/sdf-net/lib/datasets/MeshDataset.py
@@ -27,7 +27,6 @@ from torch.utils.data import Dataset
 import numpy as np
 import pysdf
 import mesh2sdf
-import spc
 
 from ..torchgp import load_obj, point_sample, sample_surface, compute_sdf, normalize
 from ..PsDebugger import PsDebugger


### PR DESCRIPTION
Little updates to requirements to be able to run nglod training (`app.main`) on Google Colab:

1. pysdf missing from requirements --> added to requirements.txt
2. Some flows use `torch.clip`, which is only available from torch 1.7.0 and onwards (tested with CUDA 11) --> requirements.txt updated
3.  MeshDataset has a stale `import spc` statement which fails the training code --> removed from MeshDataset

Another change required to run training, and not included in this pull-request:
The `armadillo_normalized.obj` model is n/a, so possibly the normalization code of MeshDataset should be uncommented (I'm not sure how other flows may be affected).
