### PR TITLE
Update tinyobjloader dependency

### DIFF
--- a/infra/requirements.txt
+++ b/infra/requirements.txt
@@ -2,7 +2,7 @@ torch==1.6.0
 torchvision==0.7.0
 tensorboard
 matplotlib
-git+https://github.com/tinyobjloader/tinyobjloader.git#subdirectory=python
+git+https://github.com/tinyobjloader/tinyobjloader.git
 pybind11
 trimesh>=3.0
 tqdm


### PR DESCRIPTION
Seems like the `#subdirectory=python` part in [requirements.txt](https://github.com/nv-tlabs/nglod/blob/main/infra/requirements.txt) had to be removed to install ```tinyobjloader``` properly. 